### PR TITLE
Get Solution file path to Buildalyzer on ProjectAnalyze

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -53,7 +53,10 @@ namespace Stryker.Core.Initialisation
             string targetFramework,
             string msBuildPath = null)
         {
-
+            // Buildalyzers need solution path 
+            if (string.IsNullOrEmpty(AnalyzerManager.SolutionFilePath) && !string.IsNullOrEmpty(solutionFilePath)) {
+                _analyzerManager = _analyzerProvider.Provide(solutionFilePath, new AnalyzerManagerOptions{LogWriter = _buildalyzerLog});
+            }
             _logger.LogDebug("Analyzing project file {0}", projectFilePath);
             var analyzerResult = GetProjectInfo(projectFilePath, targetFramework);
             LogAnalyzerResult(analyzerResult);


### PR DESCRIPTION
For specific project, we need to pass the solution path to buildalyzer to avoid warn message " Buildalyzer could not find sourcefiles. This should not happen. Will fallback to filesystem scan. Please report an issue at github."